### PR TITLE
Fixed text displayed after routes creation

### DIFF
--- a/cmds/routes.go
+++ b/cmds/routes.go
@@ -46,7 +46,7 @@ func NewCmdRoutes(f *cmdutil.Factory) *cobra.Command {
 				util.Fatal("No default namespace")
 				printResult("Get default namespace", Failure, err)
 			} else {
-				util.Info("Setting up routes on your")
+				util.Info("Setting up routes on your ")
 				util.Success(string(util.TypeOfMaster(c)))
 				util.Info(" installation at ")
 				util.Success(cfg.Host)

--- a/cmds/routes.go
+++ b/cmds/routes.go
@@ -46,7 +46,7 @@ func NewCmdRoutes(f *cmdutil.Factory) *cobra.Command {
 				util.Fatal("No default namespace")
 				printResult("Get default namespace", Failure, err)
 			} else {
-				util.Info("Creating a persistent volume for your ")
+				util.Info("Setting up routes on your")
 				util.Success(string(util.TypeOfMaster(c)))
 				util.Info(" installation at ")
 				util.Success(cfg.Host)


### PR DESCRIPTION
When running
```
gofabric8 ... routes
```
after successful creation we see:
```
Creating a persistent volume for your ...
```
I have fixed it to
```
Setting up routes on your ...
```