### PR TITLE
add gofabric8 start command

### DIFF
--- a/cmds/service.go
+++ b/cmds/service.go
@@ -102,7 +102,7 @@ func CheckService(ns string, service string, c *k8sclient.Client) error {
 	}
 	url := svc.ObjectMeta.Annotations[exposeURLAnnotation]
 	if url == "" {
-		util.Infof("Waiting, external URL for %s service is not ready yet... \n", service)
+		util.Info(".")
 		return errors.New("")
 	}
 	endpoints := c.Endpoints(ns)
@@ -121,7 +121,7 @@ func CheckService(ns string, service string, c *k8sclient.Client) error {
 // Credits: https://github.com/kubernetes/minikube/blob/v0.9.0/cmd/minikube/cmd/service.go#L101
 func CheckEndpointReady(endpoint *kubeApi.Endpoints) error {
 	if len(endpoint.Subsets) == 0 {
-		fmt.Fprintf(os.Stderr, "Waiting, endpoint for service is not ready yet...\n")
+		fmt.Fprintf(os.Stderr, ".")
 		return fmt.Errorf("Endpoint for service is not ready yet\n")
 	}
 	for _, subset := range endpoint.Subsets {

--- a/cmds/start.go
+++ b/cmds/start.go
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmds
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/fabric8io/gofabric8/util"
+	"github.com/spf13/cobra"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+const (
+	defaultMemory = "4096"
+	defaultCPU    = "1"
+	openshift     = "shift"
+)
+
+// NewCmdStart starts a local cloud environment
+func NewCmdStart(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Starts a local cloud development environment",
+		Long:  `Starts a local cloud development environment`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+
+			flag := cmd.Flags().Lookup(openshift)
+			isOpenshift := false
+			if flag != nil {
+				isOpenshift = flag.Value.String() == "true"
+			}
+			if isOpenshift {
+				kubeBinary = minishift
+			}
+
+			// check if already running
+			// TODO: should we vendor the minikube and minishift status packages rather than using exec?
+			out, err := exec.Command(kubeBinary, "status").Output()
+			status := strings.TrimSpace(string(out))
+			if err == nil && status == "Running" {
+				// already running so lets
+				util.Successf("%s already running\n", kubeBinary)
+
+			} else {
+				args := []string{"start", "--memory=" + defaultMemory, "--cpus=" + defaultCPU}
+				if runtime.GOOS == "darwin" {
+					args = append(args, "--vm-driver=xhyve")
+				}
+				// start the local VM
+				e := exec.Command(kubeBinary, args...)
+				e.Stdout = os.Stdout
+				e.Stderr = os.Stderr
+				err = e.Run()
+				if err != nil {
+					util.Errorf("Unable to start %v", err)
+				}
+			}
+
+			// now check that fabric8 is running, if not deploy it
+			c, err := keepTryingToGetClient(f)
+			if err != nil {
+				util.Fatalf("Unable to connect to %s", kubeBinary)
+			}
+
+			// deploy fabric8 if its not already running
+			ns, _, _ := f.DefaultNamespace()
+			_, err = c.Services(ns).Get("fabric8")
+			if err != nil {
+				util.Info("deploying the fabric8 microservices platform")
+				// how best to call the deploy code without setting PersistentFlags?
+			} else {
+				openService(ns, "fabric8", c, false)
+			}
+		},
+	}
+	//cmd.PersistentFlags().BoolP(openshift, "s", false, "start the openshift flavour of Kubernetes")
+	return cmd
+}
+
+func keepTryingToGetClient(f *cmdutil.Factory) (*client.Client, error) {
+	timeout := time.After(2 * time.Minute)
+	tick := time.Tick(1 * time.Second)
+	// Keep trying until we're timed out or got a result or got an error
+	for {
+		select {
+		// Got a timeout! fail with a timeout error
+		case <-timeout:
+			return nil, errors.New("timed out")
+		// Got a tick, try and get teh client
+		case <-tick:
+			c, _ := getClient(f)
+			// return if we have a client
+			if c != nil {
+				return c, nil
+			}
+			util.Info("Cannot connect to api server, retrying...")
+			// retry
+		}
+	}
+}
+
+func getClient(f *cmdutil.Factory) (*client.Client, error) {
+	var err error
+	cfg, err := f.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/cmds/volumes.go
+++ b/cmds/volumes.go
@@ -148,7 +148,7 @@ func configureHostPathVolume(c *k8sclient.Client, ns string, hostPath string, co
 		}
 		if len(nodes.Items) == 1 {
 			node := nodes.Items[0]
-			if node.Name == minikubeNodeName || node.Name == minishiftNodeName {
+			if node.Name == minikubeNodeName || node.Name == minishiftNodeName || node.Name == boot2docker {
 				// lets figure out which one we are
 				// TODO there's no obvious annotation yet to know
 				// if it was created via minikube or minishift

--- a/gofabric8.go
+++ b/gofabric8.go
@@ -98,6 +98,7 @@ func main() {
 	cmds.AddCommand(commands.NewCmdRoutes(f))
 	cmds.AddCommand(commands.NewCmdSecrets(f))
 	cmds.AddCommand(commands.NewCmdService(f))
+	cmds.AddCommand(commands.NewCmdStart(f))
 	cmds.AddCommand(commands.NewCmdVolumes(f))
 	cmds.AddCommand(commands.NewCmdVersion())
 


### PR DESCRIPTION
this command can be used to start minishift or minikube and automatically deploy fabric8.  
Example usage:
```
gofabric8 start
gofabric8 start --minishift
gofabric8 start --console
gofabric8 start --console --memory=1024 --cpus=2
```