### PR TITLE
enable persistence by default now that we use dynamic persistence or gofabric8 volumes to create PV fixes #268

### DIFF
--- a/cmds/volumes.go
+++ b/cmds/volumes.go
@@ -177,11 +177,6 @@ func configureHostPathVolume(c *k8sclient.Client, ns string, hostPath string, ss
 
 	if len(cli) == 0 {
 		context, isMini, _ := util.GetMiniType()
-		// during initial deploy we cant rely on just the current context - we need to check the node names too
-		// see https://github.com/jimmidyson/minishift/issues/94
-		if !isMini {
-			context, isMini = isNodeNameMini(c, ns)
-		}
 		if isMini {
 			cli = context
 		}


### PR DESCRIPTION
- also properly detect if we're running against minishift fixes #280 
- adds a summary to the new docs if any PVCs dont bind after `gofabric8 deploy`

New docs to explain setting up persistence if not done automatically http://fabric8.io/guide/getStarted/persistence.html