### PR TITLE
Update download script & README to show bashrc, as well as zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ add '~/.fabric8/bin' to your path so you can execute the new binaries, for examp
 edit your ~/.zshrc or ~/.bashrc  and append to the end of the file
 ```
 export PATH=\$PATH:~/.fabric8/bin
-source ~/.zshrc or ~/.zshrc
+source ~/.zshrc or ~/.bashrc
 ```
 
 #### minikube

--- a/getfabric8.sh
+++ b/getfabric8.sh
@@ -107,7 +107,7 @@ echo
 echo "For example:"
 echo "Edit your ~/.zshrc or ~/.bashrc  and append to the end of the file"
 echo "export PATH=\$PATH:~/.fabric8/bin"
-echo "source ~/.zshrc or ~/.zshrc"
+echo "source ~/.zshrc or ~/.bashrc"
 echo 
 echo "To work with the fabric8 microservices platform either:"
 echo " - 'gofabric8 install' for a local cloud development platform" 


### PR DESCRIPTION
README and getfabric8.sh both repeat mention of zshrc, rather than zshrc and bashrc.  Corrected.  

Observed this when ran `curl -sS https://get.fabric8.io/download.txt | bash`, and saw in the gofabri8 cli.  It's at least wrong in the code; still working to prove that download.txt is built from getfabric8.sh.  