### PR TITLE
Rename delete to delete cluster

### DIFF
--- a/cmds/cluster.go
+++ b/cmds/cluster.go
@@ -27,9 +27,9 @@ import (
 const ()
 
 // NewCmdDelete deletes the current local cluster
-func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+func NewCmdDeleteCluster(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "cluster",
 		Short: "Delete a local cluster",
 		Long:  `Delete a local cluster. This command deletes the VM and removes all`,
 

--- a/cmds/cruds.go
+++ b/cmds/cruds.go
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmds
+
+import "github.com/spf13/cobra"
+
+const (
+	longhelp = `You must specify the type of resource to get. Valid resource types include:
+* cluster.
+`
+)
+
+func NewCmdDelete() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a resource type",
+		Long:  longhelp,
+		Run: func(cmd *cobra.Command, args []string) {
+		},
+	}
+	return cmd
+}

--- a/gofabric8.go
+++ b/gofabric8.go
@@ -118,12 +118,15 @@ func main() {
 	cmds.AddCommand(commands.NewCmdStart(f))
 	cmds.AddCommand(commands.NewCmdStatus(f))
 	cmds.AddCommand(commands.NewCmdStop(f))
-	cmds.AddCommand(commands.NewCmdDelete(f))
 	cmds.AddCommand(commands.NewCmdValidate(f))
 	cmds.AddCommand(commands.NewCmdUpgrade(f))
 	cmds.AddCommand(commands.NewCmdVersion())
 	cmds.AddCommand(commands.NewCmdVolumes(f))
 	cmds.AddCommand(commands.NewCmdWaitFor(f))
+
+	deletecmd := commands.NewCmdDelete()
+	cmds.AddCommand(deletecmd)
+	deletecmd.AddCommand(commands.NewCmdDeleteCluster(f))
 
 	cmds.Execute()
 }


### PR DESCRIPTION
Following discussion on #362

This allows us to add more commands in the future that does CRUD types
object manipulation.

This probably would need to be mentioned in the RELEASE notes!
