### PR TITLE
Add "gofabric8 get environ"

### DIFF
--- a/cmds/cluster.go
+++ b/cmds/cluster.go
@@ -26,7 +26,7 @@ import (
 
 const ()
 
-// NewCmdDelete deletes the current local cluster
+// NewCmdDeleteCluster deletes the current local cluster
 func NewCmdDeleteCluster(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",

--- a/cmds/cruds.go
+++ b/cmds/cruds.go
@@ -20,6 +20,7 @@ import "github.com/spf13/cobra"
 const (
 	longhelp = `You must specify the type of resource to get. Valid resource types include:
 * cluster.
+* environ.
 `
 )
 
@@ -28,8 +29,15 @@ func NewCmdDelete() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete a resource type",
 		Long:  longhelp,
-		Run: func(cmd *cobra.Command, args []string) {
-		},
+	}
+	return cmd
+}
+
+func NewCmdGet() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a resource type",
+		Long:  `get a resource type`,
 	}
 	return cmd
 }

--- a/cmds/environ.go
+++ b/cmds/environ.go
@@ -1,0 +1,73 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	k8client "k8s.io/kubernetes/pkg/client/unversioned"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+type EnvironmentData struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+	Order     int    `yaml:"order"`
+}
+
+func NewCmdGetEnviron(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "environ",
+		Short: "Get environment from fabric8-environments configmap",
+		Run: func(cmd *cobra.Command, args []string) {
+			c, ns := getKubeClient(cmd, f)
+			selector, err := unversioned.LabelSelectorAsSelector(
+				&unversioned.LabelSelector{MatchLabels: map[string]string{"kind": "environments"}})
+			cmdutil.CheckErr(err)
+
+			cfgmap, err := c.ConfigMaps(ns).List(api.ListOptions{LabelSelector: selector})
+			cmdutil.CheckErr(err)
+
+			fmt.Printf("%-10s DATA\n", "ENV")
+			for _, item := range cfgmap.Items {
+				for key, data := range item.Data {
+					var ed EnvironmentData
+					err := yaml.Unmarshal([]byte(data), &ed)
+					cmdutil.CheckErr(err)
+					fmt.Printf("%-10s name=%s namespace=%s order=%d\n",
+						key, ed.Name, ed.Namespace, ed.Order)
+				}
+			}
+		},
+	}
+	// NB(chmou): we may try to do the whole shenanigans like kubectl/oc does for
+	// outputting stuff but currently this is like swatting flies with a
+	// sledgehammer.
+	// cmdutil.AddPrinterFlags(cmd)
+	return cmd
+}
+
+func getKubeClient(cmd *cobra.Command, f *cmdutil.Factory) (c *k8client.Client, ns string) {
+	c, _, err := keepTryingToGetClient(f)
+	cmdutil.CheckErr(err)
+	ns, _, err = f.DefaultNamespace()
+	cmdutil.CheckErr(err)
+
+	return c, ns
+}

--- a/gofabric8.go
+++ b/gofabric8.go
@@ -124,6 +124,10 @@ func main() {
 	cmds.AddCommand(commands.NewCmdVolumes(f))
 	cmds.AddCommand(commands.NewCmdWaitFor(f))
 
+	getcmd := commands.NewCmdGet()
+	cmds.AddCommand(getcmd)
+	getcmd.AddCommand(commands.NewCmdGetEnviron(f))
+
 	deletecmd := commands.NewCmdDelete()
 	cmds.AddCommand(deletecmd)
 	deletecmd.AddCommand(commands.NewCmdDeleteCluster(f))


### PR DESCRIPTION
- Listing the environment set in the `fabric8-environments` configmap.
- This parse the yamldata part into a go struct
- The outputter is pretty simple currently may have room for improvement
  if needed.
- Fixes #362 