### PR TITLE
Always use k8s-template prefix

### DIFF
--- a/cmds/deploy.go
+++ b/cmds/deploy.go
@@ -633,11 +633,7 @@ func getTemplateURI(packageName, mavenRepo string, legacyPackage bool, d Default
 
 	if typeOfMaster == util.Kubernetes {
 		if !strings.HasPrefix(uri, "file://") {
-			if legacyPackage {
-				uri += "kubernetes.yml"
-			} else {
-				uri += "k8s-template.yml"
-			}
+			uri += "kubernetes.yml"
 		}
 
 	} else {


### PR DESCRIPTION
-k8s-template.yml doesn't seem generated anymore according to : 

https://repo1.maven.org/maven2/io/fabric8/platform/packages/fabric8-platform/2.4.24/