### PR TITLE
Allow deleting tenant as another user

### DIFF
--- a/cmds/common.go
+++ b/cmds/common.go
@@ -55,6 +55,7 @@ const (
 	apiServerFlag = "api-server"
 	consoleFlag   = "console"
 	templatesFlag = "templates"
+	asFlag        = "as"
 	DefaultDomain = ""
 )
 


### PR DESCRIPTION
For example if you need to delete other tenant as system:admin
Only execute when we are running the mini{shift,kube} but print when running in
remote.