### PR TITLE
lets try use the default client to avoid issues running in pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,10 @@ release: check
 clean:
 	rm -rf build release
 
-docker:
+linux:
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o build/$(NAME)-linux-amd64 $(NAME).go
+
+docker: linux
 	docker build -t fabric8/gofabric8 .
 
 .PHONY: release clean arm

--- a/client/client.go
+++ b/client/client.go
@@ -21,10 +21,12 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
 )
 
 func NewClient(f cmdutil.Factory) (*clientset.Clientset, *restclient.Config) {
 	var err error
+
 	cfg, err := f.ClientConfig()
 	if err != nil {
 		util.Error("Could not initialise a client - is your server setting correct?\n\n")
@@ -37,6 +39,18 @@ func NewClient(f cmdutil.Factory) (*clientset.Clientset, *restclient.Config) {
 	}
 
 	return c, cfg
+}
+
+func NewDefaultClient(f cmdutil.Factory) (*clientset.Clientset, *restclient.Config, error) {
+	c, err := f.ClientSet()
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg, err := f.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, cfg, nil
 }
 
 func NewOpenShiftClient(cfg *restclient.Config) (*oclient.Client, *restclient.Config) {

--- a/cmds/e2e_env.go
+++ b/cmds/e2e_env.go
@@ -56,7 +56,10 @@ func NewCmdE2eEnv(f cmdutil.Factory) *cobra.Command {
 }
 
 func (p *e2eEnvFlags) runTest(f cmdutil.Factory) error {
-	c, cfg := client.NewClient(f)
+	c, cfg, err := client.NewDefaultClient(f)
+	if err != nil {
+		c, cfg = client.NewClient(f)
+	}
 	oc, _ := client.NewOpenShiftClient(cfg)
 
 	initSchema()


### PR DESCRIPTION
using the default client method seems to work better inside clusters