### PR TITLE
Remove warning about minishift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ gofabric8 install
 ```
 #### minishift
 
-__NOTE__ currently the latest version of minishift that fabric8 currently runs on is 0.9.0
 ```
 gofabric8 install --minishift
 ```


### PR DESCRIPTION
I use gofabric8 with minishift version `v1.7.0+9af9a4fd` so this cant be true.