### PR TITLE
Remove linux driver warning if it is installed already

### DIFF
--- a/cmds/install.go
+++ b/cmds/install.go
@@ -180,7 +180,18 @@ func downloadDriver() (err error) {
 		}
 
 	} else if runtime.GOOS == "linux" {
-		return errors.New("Driver install for " + runtime.GOOS + " not yet supported")
+		docs := "https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html#kvm-driver-install"
+		driver := "docker-machine-driver-kvm"
+
+		path, err := exec.LookPath(driver)
+
+		if err != nil {
+			util.Infof("fabric8 recommends linux users use the %v driver\n", driver)
+			util.Infof("See %v for setup instructions\n", docs)
+			return errors.New(driver)
+		} else {
+			util.Successf("KVM driver is already available on your PATH at %s\n", path)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Case 1: the driver is installed

```
KVM driver is already available on your PATH at /usr/local/bin/docker-machine-driver-kvm
minikube is already available on your PATH at /home/j/.fabric8/bin/minikube
kubectl is already available on your PATH at /home/j/.fabric8/bin/kubectl
```

Otherwise

```
fabric8 recommends linux users use the docker-machine-driver-kvm driver
See https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html#kvm-driver-install for setup instructions
Unable to download driver docker-machine-driver-kvm
minikube is already available on your PATH at /home/j/.fabric8/bin/minikube
kubectl is already available on your PATH at /home/j/.fabric8/bin/kubectl
```