### PR TITLE
Wrong extension for minishift latest version.

### DIFF
--- a/cmds/install.go
+++ b/cmds/install.go
@@ -257,9 +257,7 @@ func downloadMinishift(d downloadProperties) error {
 	}
 
 	kubeURL := fmt.Sprintf(d.downloadURL+d.kubeDistroRepo+"/releases/"+d.extraPath+"v%s/%s-%s-%s-%s%s", latestVersion, d.kubeDistroRepo, latestVersion, os, arch, ext)
-	if runtime.GOOS == "windows" {
-		kubeURL += ".exe"
-	}
+
 	util.Infof("Downloading %s...\n", kubeURL)
 
 	fullPath := filepath.Join(getFabric8BinLocation(), d.kubeBinary+ext)


### PR DESCRIPTION
.exe is getting appended to the latest version for windows, which is actually a zip file.
 making the url "https://github.com/minishift/minishift/releases/download/v1.12.0/minishift-1.12.0-windows-amd64.zip.exe..." which is incorrect.